### PR TITLE
Variable moves to support usage as a module

### DIFF
--- a/config.auto.tfvars
+++ b/config.auto.tfvars
@@ -4,6 +4,12 @@
 aws_region    = "eu-west-2"
 vpc_endpoints = ["ec2", "rds", "sqs", "sns", "ssm", "logs", "ssmmessages", "ec2messages", "autoscaling", "ecs", "athena"]
 
+tags = {
+  Product    = "Network_Automation"
+  Owner      = "WWPS"
+  Project_ID = "12345"
+}
+
 env_config = {
   dev = {
     ipam_cidr        = "10.0.0.0/10"

--- a/example-spoke-vpc/config.auto.tfvars
+++ b/example-spoke-vpc/config.auto.tfvars
@@ -5,6 +5,12 @@ aws_region                = "eu-west-2"
 vpc_endpoints             = ["s3"]
 centralised_vpc_endpoints = ["ec2", "rds", "sqs", "sns", "ssm", "logs", "ssmmessages", "ec2messages", "autoscaling", "ecs", "athena"]
 
+tags = {
+  Product    = "Network_Automation"
+  Owner      = "WWPS"
+  Project_ID = "12345"
+}
+
 env_config = {
   dev = {
     network_hub_account_number = ""

--- a/example-spoke-vpc/locals.tf
+++ b/example-spoke-vpc/locals.tf
@@ -6,12 +6,12 @@ locals {
 }
 
 locals {
-  tags = {
-    Product    = "Network_Automation"
-    Owner      = "WWPS"
-    Project_ID = "12345"
-    Env        = var.environment
-  }
+  tags = merge(
+    var.tags,
+    {
+      Env = var.environment
+    },
+  )
 
   availability_zone_names = data.aws_availability_zones.available.names
   endpoints               = { for e in var.vpc_endpoints : "com.amazonaws.${var.aws_region}.${e}" => "${e}.${var.aws_region}.amazonaws.com" }

--- a/example-spoke-vpc/modules/dns/provider.tf
+++ b/example-spoke-vpc/modules/dns/provider.tf
@@ -15,7 +15,7 @@ provider "aws" {
   alias  = "network_hub"
   region = var.aws_region
   assume_role {
-    role_arn = "arn:aws:iam::${var.network_hub_account_number}:role/network_automation_role"
+    role_arn = "arn:aws:iam::${var.network_hub_account_number}:role/${var.environment}_network_automation_role"
     # Declaring a session name
     session_name = "network_hub"
   }

--- a/example-spoke-vpc/modules/network/provider.tf
+++ b/example-spoke-vpc/modules/network/provider.tf
@@ -15,7 +15,7 @@ provider "aws" {
   alias  = "network_hub"
   region = var.aws_region
   assume_role {
-    role_arn = "arn:aws:iam::${var.network_hub_account_number}:role/network_automation_role"
+    role_arn = "arn:aws:iam::${var.network_hub_account_number}:role/${var.environment}_network_automation_role"
     # Declaring a session name
     session_name = "network_hub"
   }

--- a/example-spoke-vpc/provider.tf
+++ b/example-spoke-vpc/provider.tf
@@ -22,7 +22,7 @@ provider "aws" {
   alias  = "network_hub"
   region = var.aws_region
   assume_role {
-    role_arn = "arn:aws:iam::${local.config.network_hub_account_number}:role/network_automation_role"
+    role_arn = "arn:aws:iam::${local.config.network_hub_account_number}:role/${var.environment}_network_automation_role"
     # Declaring a session name
     session_name = "network_hub"
   }

--- a/example-spoke-vpc/variables.tf
+++ b/example-spoke-vpc/variables.tf
@@ -29,3 +29,8 @@ variable "centralised_vpc_endpoints" {
   description = "Which centralised VPC endpoints to consume"
   type        = list(string)
 }
+
+variable "tags" {
+  description = "Default tags to apply to all resources"
+  type        = map(string)
+}

--- a/locals.tf
+++ b/locals.tf
@@ -6,12 +6,12 @@ locals {
 }
 
 locals {
-  tags = {
-    Product    = "Network_Automation"
-    Owner      = "WWPS"
-    Project_ID = "12345"
-    Env        = var.environment
-  }
+  tags = merge(
+    var.tags,
+    {
+      Env = var.environment
+    },
+  )
   aws_org_arn             = data.aws_organizations_organization.main.arn
   availability_zone_names = data.aws_availability_zones.available.names
   endpoints               = { for e in var.vpc_endpoints : "com.amazonaws.${var.aws_region}.${e}" => "${e}.${var.aws_region}.amazonaws.com" }

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ module "network_firewall_vpc" {
 
 resource "aws_iam_role" "central_network" {
   #checkov:skip=CKV_AWS_60: Automation role - requires Org perm with additional tag based condition for sample only
-  name               = "network_automation_role"
+  name               = "${var.environment}_network_automation_role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -102,9 +102,9 @@ EOF
 }
 
 resource "aws_iam_policy" "central_network" {
-  name        = "central_network_automation_policy"
+  name        = "${var.environment}_central_network_automation_policy"
   path        = "/"
-  description = "Central network automation policy to allow TGW association, propagation and route53 private hosted zone association"
+  description = "${var.environment} Central network automation policy to allow TGW association, propagation and route53 private hosted zone association"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -164,7 +164,7 @@ resource "aws_iam_policy_attachment" "central_network" {
 }
 
 resource "aws_iam_role" "flow_logs" {
-  name = "endpoint_vpc_flow_logs"
+  name = "${var.environment}_endpoint_vpc_flow_logs"
 
   assume_role_policy = <<EOF
 {

--- a/variables.tf
+++ b/variables.tf
@@ -24,3 +24,8 @@ variable "vpc_endpoints" {
   description = "Which VPC endpoints to use"
   type        = list(string)
 }
+
+variable "tags" {
+  description = "Default tags to apply to all resources"
+  type        = map(string)
+}


### PR DESCRIPTION
*Description of changes:*

Moved the `tags` definition from being a hard coded value in the `locals.tf` file to a variable that can be defined.  This change allows the module to be used as a sub-module to another Terraform config.

The new `tags` variable is merged with the `environment` variable to form the full list of tags to be applied to all resources.

```hcl
# main.tf
module "network_hub_east_1" {
  source        = "github.com/aws-samples/aws-network-hub-for-terraform"
  environment   = "us_east_1"
  aws_region    = "us-east-1"
  vpc_endpoints = var.vpc_endpoints
  env_config    = var.env_config
  tags          = var.tags
}

module "network_hub_east_2" {
  source        = "github.com/aws-samples/aws-network-hub-for-terraform"
  environment   = "us_east_2"
  aws_region    = "us-east-2"
  vpc_endpoints = var.vpc_endpoints
  env_config    = var.env_config
  tags          = var.tags
}
```


Signed-off-by: Michael Ethridge <michael.ethridge@wwt.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
