### PR TITLE
Add missing Terraform-docs config files

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,20 @@
+formatter: markdown table
+
+recursive:
+  enabled: true
+  path: modules
+
+settings:
+  anchor: false
+  escape: false
+  indent: 4
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+
+    {{ .Content }}
+
+    <!-- END_TF_DOCS -->

--- a/modules/dns/.terraform-docs.yml
+++ b/modules/dns/.terraform-docs.yml
@@ -1,0 +1,16 @@
+formatter: markdown table
+
+settings:
+  anchor: false
+  escape: false
+  indent: 4
+
+output:
+  file: ../../README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DNS_DOCS -->
+
+    {{ .Content }}
+
+    <!-- END_TF_DNS_DOCS -->

--- a/modules/ipam/.terraform-docs.yml
+++ b/modules/ipam/.terraform-docs.yml
@@ -1,0 +1,16 @@
+formatter: markdown table
+
+settings:
+  anchor: false
+  escape: false
+  indent: 4
+
+output:
+  file: ../../README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_IPAM_DOCS -->
+
+    {{ .Content }}
+
+    <!-- END_TF_IPAM_DOCS -->

--- a/modules/network_firewall_vpc/.terraform-docs.yml
+++ b/modules/network_firewall_vpc/.terraform-docs.yml
@@ -1,0 +1,16 @@
+formatter: markdown table
+
+settings:
+  anchor: false
+  escape: false
+  indent: 4
+
+output:
+  file: ../../README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_NFW_DOCS -->
+
+    {{ .Content }}
+
+    <!-- END_TF_NFW_DOCS -->

--- a/modules/tgw/.terraform-docs.yml
+++ b/modules/tgw/.terraform-docs.yml
@@ -1,0 +1,16 @@
+formatter: markdown table
+
+settings:
+  anchor: false
+  escape: false
+  indent: 4
+
+output:
+  file: ../../README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_TGW_DOCS -->
+
+    {{ .Content }}
+
+    <!-- END_TF_TGW_DOCS -->

--- a/modules/vpc_endpoints/.terraform-docs.yml
+++ b/modules/vpc_endpoints/.terraform-docs.yml
@@ -2,6 +2,7 @@ formatter: markdown table
 
 settings:
   anchor: false
+  escape: false
   indent: 4
 
 output:
@@ -9,5 +10,7 @@ output:
   mode: inject
   template: |-
     <!-- BEGIN_TF_VPCE_DOCS -->
+
     {{ .Content }}
+
     <!-- END_TF_VPCE_DOCS -->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add missing Terraform-docs config files. Only the one for `vpc_endpoints` was already available in the repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
