### PR TITLE
Add missing Terraform-docs config files for spoke example too

### DIFF
--- a/example-spoke-vpc/.terraform-docs.yml
+++ b/example-spoke-vpc/.terraform-docs.yml
@@ -1,0 +1,20 @@
+formatter: markdown table
+
+recursive:
+  enabled: true
+  path: modules
+
+settings:
+  anchor: false
+  escape: false
+  indent: 4
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+
+    {{ .Content }}
+
+    <!-- END_TF_DOCS -->

--- a/example-spoke-vpc/modules/dns/.terraform-docs.yml
+++ b/example-spoke-vpc/modules/dns/.terraform-docs.yml
@@ -1,0 +1,16 @@
+formatter: markdown table
+
+settings:
+  anchor: false
+  escape: false
+  indent: 4
+
+output:
+  file: ../../README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DNS_DOCS -->
+
+    {{ .Content }}
+
+    <!-- END_TF_DNS_DOCS -->

--- a/example-spoke-vpc/modules/network/.terraform-docs.yml
+++ b/example-spoke-vpc/modules/network/.terraform-docs.yml
@@ -1,0 +1,16 @@
+formatter: markdown table
+
+settings:
+  anchor: false
+  escape: false
+  indent: 4
+
+output:
+  file: ../../README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_Network_DOCS -->
+
+    {{ .Content }}
+
+    <!-- END_TF_Network_DOCS -->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add missing Terraform-docs config files for spoke example too. I kept the settings and template consistent with the ones used for the network hub, although they were using different ones before this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
