### PR TITLE
Pass provider configuration for the network hub down to spoke modules

### DIFF
--- a/example-spoke-vpc/README.md
+++ b/example-spoke-vpc/README.md
@@ -183,8 +183,8 @@ Note that this command will delete all the resources previously created by Terra
 
 | Name | Version |
 |------|---------|
-| aws | 3.71.0 |
-| aws.network\_hub | 3.71.0 |
+| aws | 3.75.2 |
+| aws.network_hub | 3.75.2 |
 
 #### Modules
 
@@ -206,18 +206,25 @@ Note that this command will delete all the resources previously created by Terra
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| aws\_region | AWS region being deployed to | `string` | n/a | yes |
-| centralised\_vpc\_endpoints | Which centralised VPC endpoints to consume | `list(string)` | n/a | yes |
-| env\_config | Map of objects for per environment configuration | <pre>map(object({<br>    network_hub_account_number = string<br>    tgw_route_tables           = list(string)<br>    root_domain                = string<br>  }))</pre> | n/a | yes |
+| aws_region | AWS region being deployed to | `string` | n/a | yes |
+| az_count | Number of availability zones | `number` | `2` | no |
+| centralised_vpc_endpoints | Which centralised VPC endpoints to consume | `list(string)` | n/a | yes |
+| env_config | Map of objects for per environment configuration | <pre>map(object({<br>    network_hub_account_number = string<br>    tgw_route_tables           = list(string)<br>    root_domain                = string<br>  }))</pre> | n/a | yes |
 | environment | Deployment environment passed as argument or environment variable | `string` | n/a | yes |
-| vpc\_endpoints | Which local VPC endpoints to deploy | `list(string)` | n/a | yes |
+| tags | Default tags to apply to all resources | `map(string)` | n/a | yes |
+| vpc_endpoints | Which local VPC endpoints to deploy | `list(string)` | n/a | yes |
+| vpc_name | Name of the VPC | `string` | `"spoke"` | no |
 
 #### Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| vpc_id | vpc id used for other modules |
+
 <!-- END_TF_DOCS -->
 
 <!-- BEGIN_TF_Network_DOCS -->
+
 #### Requirements
 
 | Name | Version |
@@ -230,7 +237,7 @@ No outputs.
 | Name | Version |
 |------|---------|
 | aws | ~> 3.0 |
-| aws.network\_hub | ~> 3.0 |
+| aws.network_hub | ~> 3.0 |
 
 #### Modules
 
@@ -245,11 +252,13 @@ No modules.
 | [aws_ec2_transit_gateway_route_table_association.env](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
 | [aws_ec2_transit_gateway_route_table_propagation.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_propagation) | resource |
 | [aws_ec2_transit_gateway_vpc_attachment.vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment) | resource |
+| [aws_egress_only_internet_gateway.spoke_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/egress_only_internet_gateway) | resource |
 | [aws_flow_log.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_iam_role.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_kms_key.log_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_route.default_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.default_route_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route53_record.dev-ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.interface_phz](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route_table.spoke_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
@@ -260,6 +269,8 @@ No modules.
 | [aws_subnet.app_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.endpoint_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.spoke_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [aws_vpc_dhcp_options.spoke_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options) | resource |
+| [aws_vpc_dhcp_options_association.spoke_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options_association) | resource |
 | [aws_vpc_endpoint.interface](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.policy_kms_logs_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -269,24 +280,26 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| aws\_region | AWS region being deployed to | `string` | n/a | yes |
-| az\_names | A list of the Availability Zone names available to the account | `list(string)` | n/a | yes |
+| aws_region | AWS region being deployed to | `string` | n/a | yes |
+| az_names | A list of the Availability Zone names available to the account | `list(string)` | n/a | yes |
 | environment | Deployment environment passed as argument or environment variable | `string` | n/a | yes |
-| interface\_endpoints | object representing the region and services to create interface endpoints for | `map(string)` | n/a | yes |
-| network\_hub\_account\_number | Network Hub account ID | `string` | n/a | yes |
-| tags | default provider tags | `map(string)` | n/a | yes |
+| interface_endpoints | object representing the region and services to create interface endpoints for | `map(string)` | n/a | yes |
+| network_hub_account_number | Network Hub account ID | `string` | n/a | yes |
 | tgw | TGW route tables for VPC attachment | `string` | n/a | yes |
-| tgw\_association | tgw route table to associate to | `string` | n/a | yes |
-| tgw\_route\_table | TGW route tables for VPC association and propagation | `map(string)` | n/a | yes |
+| tgw_association | tgw route table to associate to | `string` | n/a | yes |
+| tgw_route_table | TGW route tables for VPC association and propagation | `map(string)` | n/a | yes |
+| vpc_name | Name of the VPC | `string` | `"spoke"` | no |
 
 #### Outputs
 
 | Name | Description |
 |------|-------------|
-| vpc\_id | vpc id used for other modules |
+| vpc_id | vpc id used for other modules |
+
 <!-- END_TF_Network_DOCS -->
 
 <!-- BEGIN_TF_DNS_DOCS -->
+
 #### Requirements
 
 | Name | Version |
@@ -299,7 +312,7 @@ No modules.
 | Name | Version |
 |------|---------|
 | aws | ~> 3.0 |
-| aws.network\_hub | ~> 3.0 |
+| aws.network_hub | ~> 3.0 |
 
 #### Modules
 
@@ -327,15 +340,15 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| aws\_region | AWS region being deployed to | `string` | n/a | yes |
-| centralised\_vpc\_endpoints | Which centralised VPC endpoints to consume | `map(string)` | n/a | yes |
+| aws_region | AWS region being deployed to | `string` | n/a | yes |
+| centralised_vpc_endpoints | Which centralised VPC endpoints to consume | `map(string)` | n/a | yes |
 | environment | Deployment environment passed as argument or environment variable | `string` | n/a | yes |
-| network\_hub\_account\_number | Network Hub account ID | `string` | n/a | yes |
-| root\_domain | rootdomain for the delegated private hosted zone | `string` | n/a | yes |
-| tags | default provider tags | `map(string)` | n/a | yes |
-| vpc\_id | vpc id to associate delegated subdomain to | `string` | n/a | yes |
+| network_hub_account_number | Network Hub account ID | `string` | n/a | yes |
+| root_domain | rootdomain for the delegated private hosted zone | `string` | n/a | yes |
+| vpc_id | vpc id to associate delegated subdomain to | `string` | n/a | yes |
 
 #### Outputs
 
 No outputs.
+
 <!-- END_TF_DNS_DOCS -->

--- a/example-spoke-vpc/README.md
+++ b/example-spoke-vpc/README.md
@@ -285,7 +285,7 @@ No modules.
 | environment | Deployment environment passed as argument or environment variable | `string` | n/a | yes |
 | interface_endpoints | object representing the region and services to create interface endpoints for | `map(string)` | n/a | yes |
 | network_hub_account_number | Network Hub account ID | `string` | n/a | yes |
-| tgw | TGW route tables for VPC attachment | `string` | n/a | yes |
+| tgw | TGW ID | `string` | n/a | yes |
 | tgw_association | tgw route table to associate to | `string` | n/a | yes |
 | tgw_route_table | TGW route tables for VPC association and propagation | `map(string)` | n/a | yes |
 | vpc_name | Name of the VPC | `string` | `"spoke"` | no |

--- a/example-spoke-vpc/main.tf
+++ b/example-spoke-vpc/main.tf
@@ -2,6 +2,10 @@
    SPDX-License-Identifier: MIT-0 */
 
 module "network" {
+  providers = {
+    aws.network_hub = aws.network_hub
+  }
+
   source                     = "./modules/network"
   az_names                   = local.availability_zone_names
   tgw                        = data.aws_ec2_transit_gateway.org_env.id
@@ -16,6 +20,10 @@ module "network" {
 }
 
 module "dns" {
+  providers = {
+    aws.network_hub = aws.network_hub
+  }
+
   source                     = "./modules/dns"
   environment                = var.environment
   centralised_vpc_endpoints  = local.centralised_endpoints

--- a/example-spoke-vpc/main.tf
+++ b/example-spoke-vpc/main.tf
@@ -12,7 +12,6 @@ module "network" {
   interface_endpoints        = local.endpoints
   tgw_route_table            = local.tgw_route_table
   tgw_association            = data.aws_ec2_transit_gateway_route_table.associate.id
-  tags                       = local.tags
   network_hub_account_number = local.config.network_hub_account_number
   aws_region                 = var.aws_region
   environment                = var.environment
@@ -29,7 +28,6 @@ module "dns" {
   centralised_vpc_endpoints  = local.centralised_endpoints
   vpc_id                     = module.network.vpc_id
   root_domain                = local.config.root_domain
-  tags                       = local.tags
   network_hub_account_number = local.config.network_hub_account_number
   aws_region                 = var.aws_region
 }

--- a/example-spoke-vpc/modules/dns/provider.tf
+++ b/example-spoke-vpc/modules/dns/provider.tf
@@ -6,20 +6,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 3.0"
+      configuration_aliases = [ aws.network_hub ]
     }
   }
   required_version = "~> 1.1"
 }
 
-provider "aws" {
-  alias  = "network_hub"
-  region = var.aws_region
-  assume_role {
-    role_arn = "arn:aws:iam::${var.network_hub_account_number}:role/${var.environment}_network_automation_role"
-    # Declaring a session name
-    session_name = "network_hub"
-  }
-  default_tags {
-    tags = var.tags
-  }
-}

--- a/example-spoke-vpc/modules/dns/variables.tf
+++ b/example-spoke-vpc/modules/dns/variables.tf
@@ -21,11 +21,6 @@ variable "aws_region" {
   description = "AWS region being deployed to"
 }
 
-variable "tags" {
-  type        = map(string)
-  description = "default provider tags"
-}
-
 variable "network_hub_account_number" {
   type        = string
   description = "Network Hub account ID"

--- a/example-spoke-vpc/modules/network/flow_logs.tf
+++ b/example-spoke-vpc/modules/network/flow_logs.tf
@@ -34,6 +34,7 @@ resource "aws_iam_role" "flow_logs" {
 EOF
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "flow_logs" {
   name = "vpc_flow_logs"
   role = aws_iam_role.flow_logs.id

--- a/example-spoke-vpc/modules/network/flow_logs.tf
+++ b/example-spoke-vpc/modules/network/flow_logs.tf
@@ -59,7 +59,7 @@ resource "aws_iam_role_policy" "flow_logs" {
 EOF
 }
 
-# Creat a KMS key for CloudWatch Log encryption
+# Create a KMS key for CloudWatch Log encryption
 resource "aws_kms_key" "log_key" {
   description             = "KMS Logs Key"
   deletion_window_in_days = 7

--- a/example-spoke-vpc/modules/network/provider.tf
+++ b/example-spoke-vpc/modules/network/provider.tf
@@ -6,20 +6,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 3.0"
+      configuration_aliases = [ aws.network_hub ]
     }
   }
   required_version = "~> 1.1"
 }
 
-provider "aws" {
-  alias  = "network_hub"
-  region = var.aws_region
-  assume_role {
-    role_arn = "arn:aws:iam::${var.network_hub_account_number}:role/${var.environment}_network_automation_role"
-    # Declaring a session name
-    session_name = "network_hub"
-  }
-  default_tags {
-    tags = var.tags
-  }
-}

--- a/example-spoke-vpc/modules/network/variables.tf
+++ b/example-spoke-vpc/modules/network/variables.tf
@@ -31,11 +31,6 @@ variable "aws_region" {
   description = "AWS region being deployed to"
 }
 
-variable "tags" {
-  type        = map(string)
-  description = "default provider tags"
-}
-
 variable "tgw_association" {
   type        = string
   description = "tgw route table to associate to"

--- a/example-spoke-vpc/modules/network/variables.tf
+++ b/example-spoke-vpc/modules/network/variables.tf
@@ -22,7 +22,7 @@ variable "tgw_route_table" {
 }
 
 variable "tgw" {
-  description = "TGW route tables for VPC attachment"
+  description = "TGW ID"
   type        = string
 }
 

--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,7 @@ EOF
   }
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_policy" "central_network" {
   name        = "${var.environment}_central_network_automation_policy"
   path        = "/"
@@ -183,6 +184,7 @@ resource "aws_iam_role" "flow_logs" {
 EOF
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "flow_logs" {
   name = "endpoint_vpc_flow_logs"
   role = aws_iam_role.flow_logs.id

--- a/main.tf
+++ b/main.tf
@@ -209,7 +209,7 @@ resource "aws_iam_role_policy" "flow_logs" {
 EOF
 }
 
-# Creat a KMS key for CloudWatch Log encryption
+# Create a KMS key for CloudWatch Log encryption
 resource "aws_kms_key" "log_key" {
   description             = "KMS Logs Key"
   deletion_window_in_days = 7


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Without this PR, if you try to comment out a resource in the spoke's [main.tf](../blob/main/example-spoke-vpc/main.tf) file in order to destroy it without destroying anything else, e.g.:
```
#module "network" {
#  ...
#}
```
Upon running a `terraform apply` you get a series of errors as per below:
```
╷
│ Error: Provider configuration not present
│ 
│ To work with
│ module.network.aws_ec2_transit_gateway_route_table_propagation.org["name_shared"]
│ (orphan) its original provider configuration at
│ module.network.provider["registry.terraform.io/hashicorp/aws"].network_hub
│ is required, but it has been removed. This occurs when a provider
│ configuration is removed while objects created by that provider still exist
│ in the state. Re-add the provider configuration to destroy
│ module.network.aws_ec2_transit_gateway_route_table_propagation.org["name_shared"]
│ (orphan), after which you can remove the provider configuration again.
```
This PR passes the provider configuration for the network hub down to spoke modules explicitly. The non-aliased provider is passed down implicitly. The global scope of providers in Terraform does the rest.

As an added bonus, this PR implements DRY code =)

Reference: https://www.terraform.io/language/modules/develop/providers
> Additional provider configurations (those with the alias argument set) are never inherited automatically by child modules, and so must always be passed explicitly using the providers map.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
