### PR TITLE
central_network policy document

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.5.0"
   constraints = ">= 4.4.0"
   hashes = [
+    "h1:4zvgHQ1goH6KvniHe+loxRD+8NSsCOznYcGLaxK2W2E=",
     "h1:6y12cTFaxpFv4qyU3gkV9M15eSBBrgInoKY1iaHuhvg=",
     "zh:0573de96ba316d808be9f8d6fc8e8e68e0e6b614ed4d707bd236c4f7b46ac8b1",
     "zh:37560469042f5f43fdb961eb6e6b0a8f95057df68af2c1168d5b8c66ddcb1512",


### PR DESCRIPTION
*Use Terraform iam_policy_document to replace inline JSON*

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document

In addition to being cleaner, this will allow a Terraform validate to identify issue with the policy prior to an apply.

*testing*

Using the `iam_policy_document` resource the following policy document was created. 
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "",
            "Effect": "Allow",
            "Principal": {
                "AWS": "*"
            },
            "Action": "sts:AssumeRole",
            "Condition": {
                "StringEquals": {
                    "aws:PrincipalOrgID": "ou-xxxxxxxxxx"
                },
                "StringNotEqualsIgnoreCase": {
                    "aws:RequestTag/automation": "true"
                }
            }
        }
    ]
}
```

:avocado: