### PR TITLE
Feature: Conditionally Enable Ingress to spoke-vpc via org-vpc-share

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,9 @@ No modules.
 | [aws_networkfirewall_firewall_policy.anfw_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy) | resource |
 | [aws_networkfirewall_logging_configuration.network_firewall_alert_logging_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_logging_configuration) | resource |
 | [aws_networkfirewall_rule_group.block_domains](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group) | resource |
+| [aws_ram_principal_association.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_principal_association) | resource |
+| [aws_ram_resource_association.internet_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_association) | resource |
+| [aws_ram_resource_share.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share) | resource |
 | [aws_route.default_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.default_route_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.egress_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
@@ -573,6 +576,7 @@ No modules.
 | environment | Deployment environment passed as argument or environment variable | `string` | n/a | yes |
 | iam_role_arn | IAM role to allow VPC Flow Logs to write to CloudWatch | `string` | n/a | yes |
 | kms_key_id | VPC Flow Logs KMS key to encrypt logs | `string` | n/a | yes |
+| org_arn | The ARN of the AWS Organization this account belongs to | `string` | n/a | yes |
 | org_ipam_pool | IPAM pool ID to allocate CIDR space | `string` | n/a | yes |
 | tgw | TGW ID for VPC attachments | `string` | n/a | yes |
 | tgw_route_tables | TGW route tables for VPC association and propagation | `map(string)` | n/a | yes |

--- a/example-spoke-vpc/README.md
+++ b/example-spoke-vpc/README.md
@@ -100,6 +100,9 @@ aws_region                = "eu-west-2"
 vpc_endpoints             = ["s3"]
 centralised_vpc_endpoints = ["ec2", "rds", "sqs", "sns", "ssm", "logs", "ssmmessages", "ec2messages", "autoscaling", "ecs", "athena"]
 
+# Set this to true if you want to share the network-hub's public subnets with this account:
+enable_ingress            = false
+
 env_config = {
   dev = {
     network_hub_account_number = "<Network_Hub_Account_ID>"

--- a/example-spoke-vpc/README.md
+++ b/example-spoke-vpc/README.md
@@ -209,6 +209,7 @@ Note that this command will delete all the resources previously created by Terra
 | aws_region | AWS region being deployed to | `string` | n/a | yes |
 | az_count | Number of availability zones | `number` | `2` | no |
 | centralised_vpc_endpoints | Which centralised VPC endpoints to consume | `list(string)` | n/a | yes |
+| enable_ingress | Whether Ingress should be enabled by accepting the org-vpc-share | `bool` | false | no |
 | env_config | Map of objects for per environment configuration | <pre>map(object({<br>    network_hub_account_number = string<br>    tgw_route_tables           = list(string)<br>    root_domain                = string<br>  }))</pre> | n/a | yes |
 | environment | Deployment environment passed as argument or environment variable | `string` | n/a | yes |
 | tags | Default tags to apply to all resources | `map(string)` | n/a | yes |
@@ -257,6 +258,7 @@ No modules.
 | [aws_iam_role.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_kms_key.log_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_ram_principal_association.org_vpc_share_invite](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_principal_association) | resource |
 | [aws_route.default_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.default_route_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route53_record.dev-ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -274,6 +276,7 @@ No modules.
 | [aws_vpc_endpoint.interface](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.policy_kms_logs_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_ram_resource_share.org_vpc_share](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ram_resource_share) | data source |
 | [aws_ssm_parameter.ipam_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 #### Inputs
@@ -282,6 +285,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | aws_region | AWS region being deployed to | `string` | n/a | yes |
 | az_names | A list of the Availability Zone names available to the account | `list(string)` | n/a | yes |
+| enable_ingress | Whether Ingress should be enabled by accepting the org-vpc-share | `bool` | n/a | yes |
 | environment | Deployment environment passed as argument or environment variable | `string` | n/a | yes |
 | interface_endpoints | Object representing the region and services to create interface endpoints for | `map(string)` | n/a | yes |
 | network_hub_account_number | Network Hub account ID | `string` | n/a | yes |

--- a/example-spoke-vpc/config.auto.tfvars
+++ b/example-spoke-vpc/config.auto.tfvars
@@ -5,6 +5,9 @@ aws_region                = "eu-west-2"
 vpc_endpoints             = ["s3"]
 centralised_vpc_endpoints = ["ec2", "rds", "sqs", "sns", "ssm", "logs", "ssmmessages", "ec2messages", "autoscaling", "ecs", "athena"]
 
+# Set this to true if you want to share the network-hub's public subnets with this account:
+enable_ingress            = false
+
 tags = {
   Product    = "Network_Automation"
   Owner      = "WWPS"

--- a/example-spoke-vpc/main.tf
+++ b/example-spoke-vpc/main.tf
@@ -16,6 +16,7 @@ module "network" {
   aws_region                 = var.aws_region
   environment                = var.environment
   vpc_name                   = var.vpc_name
+  enable_ingress             = var.enable_ingress
 }
 
 module "dns" {

--- a/example-spoke-vpc/modules/network/data.tf
+++ b/example-spoke-vpc/modules/network/data.tf
@@ -6,4 +6,10 @@ data "aws_ssm_parameter" "ipam_pool" {
   name     = "/ipam/pool/id"
 }
 
+data "aws_ram_resource_share" "org_vpc_share" {
+  provider       = aws.network_hub
+  name           = "vpc-org-share"
+  resource_owner = "SELF"
+}
+
 data "aws_caller_identity" "current" {}

--- a/example-spoke-vpc/modules/network/ram.tf
+++ b/example-spoke-vpc/modules/network/ram.tf
@@ -1,0 +1,6 @@
+resource "aws_ram_principal_association" "org_vpc_share_invite" {
+  count              = var.enable_ingress ? 1 : 0
+  provider           = aws.network_hub
+  principal          = data.aws_caller_identity.current.account_id
+  resource_share_arn = data.aws_ram_resource_share.org_vpc_share.arn
+}

--- a/example-spoke-vpc/modules/network/variables.tf
+++ b/example-spoke-vpc/modules/network/variables.tf
@@ -11,6 +11,11 @@ variable "az_names" {
   type        = list(string)
 }
 
+variable "enable_ingress" {
+  description = "Whether Ingress should be enabled by accepting the org-vpc-share"
+  type        = bool
+}
+
 variable "interface_endpoints" {
   description = "Object representing the region and services to create interface endpoints for"
   type        = map(string)

--- a/example-spoke-vpc/variables.tf
+++ b/example-spoke-vpc/variables.tf
@@ -6,6 +6,12 @@ variable "environment" {
   type        = string
 }
 
+variable "enable_ingress" {
+  description = "Whether Ingress should be enabled by accepting the org-vpc-share"
+  type        = bool
+  default     = false
+}
+
 variable "env_config" {
   description = "Map of objects for per environment configuration"
   type = map(object({

--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,13 @@ resource "aws_iam_policy" "central_network" {
         Effect   = "Allow"
         Resource = "*"
       },
+      {
+        Action = [
+          "ram:*"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      }
     ]
   })
 }

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ module "network_firewall_vpc" {
   iam_role_arn     = aws_iam_role.flow_logs.arn
   tgw_route_tables = module.tgw.tgw_route_table
   tgw              = module.tgw.tgw
+  org_arn          = local.aws_org_arn
   org_ipam_pool    = module.ipam.org_ipam_pool
   cidr             = local.config.ipam_cidr
   az_names         = local.availability_zone_names

--- a/modules/network_firewall_vpc/variables.tf
+++ b/modules/network_firewall_vpc/variables.tf
@@ -21,6 +21,11 @@ variable "cidr" {
   type        = string
 }
 
+variable "org_arn" {
+  description = "The ARN of the AWS Organization this account belongs to"
+  type        = string
+}
+
 variable "org_ipam_pool" {
   description = "IPAM pool ID to allocate CIDR space"
   type        = string

--- a/modules/network_firewall_vpc/vpc.tf
+++ b/modules/network_firewall_vpc/vpc.tf
@@ -311,3 +311,26 @@ resource "aws_egress_only_internet_gateway" "eigw" {
     Name = "inspection_eigw"
   }
 }
+
+resource "aws_ram_resource_share" "main" {
+  name                      = "vpc-org-share"
+  allow_external_principals = false
+
+  tags = {
+    Name = "org-vpc-ram-share"
+  }
+}
+
+# Requires RAM enabled to share with AWS org:
+# enable in org master account with 'aws ram enable-sharing-with-aws-organization'
+resource "aws_ram_principal_association" "org" {
+  principal          = var.org_arn
+  resource_share_arn = aws_ram_resource_share.main.arn
+}
+
+# Requires RAM enabled to share with AWS org
+resource "aws_ram_resource_association" "internet_subnet" {
+  for_each = aws_subnet.internet_subnet
+  resource_arn = each.value.arn
+  resource_share_arn =  aws_ram_resource_share.main.arn
+}


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/aws-samples/aws-network-hub-for-terraform/issues/27

*Description of changes:*
The current solution does not easily enable Ingress to spoke accounts. Although it is possible by creating additional TF stacks to deploy - for example - ALBs in the Network-Hub account which forward to IP-based Target Groups in a Spoke account, I feel this makes IaC management & organization more difficult. 

It is my opinion that this solution should also be responsible for allowing Ingress to Spoke accounts, via a single example-spoke-vpc deployment, which I feel is helpful when provisioning new sub-accounts. 

This PR does just that, by creating a RAM resource share `org-vpc-share` from the Network-Hub account that shares the inspection_vpc's public subnets. New spoke-vpc deployments have the option of _joining_ this `org-vpc-share` by enabling an Input Flag `enable_ingress`. If enabled, the spoke-vpc module joins the VPC share, seamlessly allowing spoke-account resources like an ALB to deploy into the public subnets shared by the `org-vpc-share`. 

For me, it just makes sense to have this feature managed by these network-hub and network-spoke modules, rather than having to deploy additional cross-account stacks with cross-account dependencies. This is a one-time action managed by the same deployment responsible for provisioning spoke-vpcs. 

This feature is backwards-compatible with the current version. While now the `org-vpc-share` is created by default, new subaccounts / spoke-vpc's do not join the resource share by default unless the `enable_ingress` input is explicitly set to `true`. 

Please let me know your thoughts on this, and feel free to suggest changes (especially to the new names used). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
