### PR TITLE
Update documentation URL

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,7 +1,7 @@
 /* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
    SPDX-License-Identifier: MIT-0 */
 
-# https://www.terraform.io/language/settings/backends/configuration
+# https://developer.hashicorp.com/terraform/language/backend
 
 # HTTP backend
 


### PR DESCRIPTION
Updated documentation URL for terraform backend block.

Issue #: N/A

Description of changes: Changed one comment line, which points to Terraform documentation. The URL was invalid, and I replaced it with a valid URL for the location to find documentation on backend blocks of terraform.

